### PR TITLE
feat: Make translation batch size configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,13 @@ const builder = new addonBuilder({
       default: "gpt-4o-mini"
     },
     {
+      key: "batch_size",
+      title: "Batch Size (number of lines to translate at once)",
+      type: "number",
+      default: 60,
+      required: false,
+    },
+    {
       key: "translateto",
       title: "Translate to",
       type: "select",
@@ -389,6 +396,7 @@ builder.defineSubtitlesHandler(async function (args) {
       apikey: config.apikey ?? null,
       base_url: config.base_url ?? (config.provider === "DeepSeek API" ? "https://api.deepseek.com" : "https://api.openai.com/v1/responses"),
       model_name: config.model_name ?? defaultModelName,
+      batch_size: config.batch_size ?? 60,
     });
 
     console.log(

--- a/processfiles.js
+++ b/processfiles.js
@@ -28,7 +28,8 @@ class SubtitleProcessor {
     provider,
     apikey,
     base_url,
-    model_name
+    model_name,
+    batch_size
   ) {
     try {
       const originalSubtitleFilePath = filepath[0];
@@ -38,7 +39,7 @@ class SubtitleProcessor {
       );
       const lines = originalSubtitleContent.split("\n");
 
-      const batchSize = provider === "ChatGPT API" || provider === "DeepSeek API" ? 50 : 60;
+      const batchSize = batch_size;
       let subtitleBatch = [];
       let currentBlock = {
         iscount: true,
@@ -285,7 +286,8 @@ async function startTranslation(
   provider,
   apikey,
   base_url,
-  model_name
+  model_name,
+  batch_size
 ) {
   let filepaths = [];
   try {
@@ -317,7 +319,8 @@ async function startTranslation(
         provider,
         apikey,
         base_url,
-        model_name
+        model_name,
+        batch_size
       );
       return true;
     }

--- a/queues/translationQueue.js
+++ b/queues/translationQueue.js
@@ -14,6 +14,7 @@ const translationQueue = new Queue(
         apikey,
         base_url,
         model_name,
+        batch_size,
       } = job;
 
       console.log("Processing subtitles:", subs);
@@ -28,7 +29,8 @@ const translationQueue = new Queue(
         provider,
         apikey,
         base_url,
-        model_name
+        model_name,
+        batch_size
       );
 
       cb(null, result);


### PR DESCRIPTION
This commit introduces a new feature that allows users to configure the translation batch size directly from the addon's settings. This provides more flexibility for users who may want to translate more or fewer lines at a time, depending on their needs and the API provider's limits.

The implementation includes:

- A new 'Batch Size' number input field in the addon's configuration in `index.js`, with a default value of 60.
- The configured `batch_size` value is passed through the entire translation pipeline, from the initial subtitle request in `index.js`, through the `translationQueue.js`, and into the `processfiles.js` where the translation logic resides.
- The `processSubtitles` function in `processfiles.js` now uses this configured value to determine the number of lines to include in each translation batch, replacing the previous hardcoded value.