### PR TITLE
fix: Correct movie path generation and improve API error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -431,7 +431,8 @@ function parseId(id) {
         episode: Number(episode),
       };
     } else {
-      return { type: "movie", season: 1, episode: 1 };
+      // It's a movie
+      return { type: "movie", season: null, episode: null };
     }
   } else if (id.startsWith("dcool-")) {
     const match = id.match(/dcool-(.+)::(.+)-episode-(\d+)/);

--- a/translateProvider.js
+++ b/translateProvider.js
@@ -103,11 +103,15 @@ ${JSON.stringify(jsonInput)}`;
         // Clean response (remove markdown code blocks if present)
         responseText = responseText.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
         
-        const translatedJson = JSON.parse(responseText);
-
-        resultArray = translatedJson.texts
-          .sort((a, b) => a.index - b.index)
-          .map((item) => item.text);
+        try {
+          const translatedJson = JSON.parse(responseText);
+          resultArray = translatedJson.texts
+            .sort((a, b) => a.index - b.index)
+            .map((item) => item.text);
+        } catch (e) {
+          console.error("Failed to parse Gemini API response JSON:", responseText);
+          throw new Error("Invalid JSON response from Gemini API.");
+        }
 
         console.log(`Gemini API translated ${resultArray.length} subtitle texts`);
         break;


### PR DESCRIPTION
This commit addresses two separate issues:

1. Corrects a bug in the `parseId` function where movies were incorrectly assigned a season and episode number, leading to invalid subtitle file paths. The function now correctly returns null for movie season and episode.

2. Improves error handling for the Gemini API by wrapping the JSON.parse() call in a try-catch block. This prevents the addon from crashing on non-JSON responses and adds logging to capture the invalid API output for easier debugging.