### PR TITLE
fix: Suppress verbose Gemini API JSON parsing error log

### DIFF
--- a/translateProvider.js
+++ b/translateProvider.js
@@ -109,7 +109,6 @@ ${JSON.stringify(jsonInput)}`;
             .sort((a, b) => a.index - b.index)
             .map((item) => item.text);
         } catch (e) {
-          console.error("Failed to parse Gemini API response JSON:", responseText);
           throw new Error("Invalid JSON response from Gemini API.");
         }
 


### PR DESCRIPTION
This commit removes the detailed logging of the raw response when the Gemini API returns invalid JSON. This change was made at the user's request to keep the application logs cleaner.